### PR TITLE
[examples]: Adds example usage script, token cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ env.bak/
 venv.bak/
 
 # Spotify API token cache
+# NOTE: This could probably be handled a lot nicer. But for now this will do.
 .spotify_token_cache.json
 
 # Spyder project settings

--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# Spotify API token cache
+.spotify_token_cache.json
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/README.md
+++ b/README.md
@@ -45,8 +45,31 @@ Secure examples and tools for working with the [Spotify Web API](https://develop
 3. Add `http://localhost:8888/callback` to your Redirect URIs
 4. Copy your Client ID and Client Secret
 
-## 🎯 Usage
-### Python API
+## 🔐 Authentication & Token Persistence
+
+The library uses Spotify's OAuth 2.0 Authorization Code flow for secure authentication. Here's how it works:
+
+### First-Time Authentication
+
+When you run the library for the first time:
+
+1. **Browser Opens**: A browser window will open to Spotify's authorization page
+2. **User Consent**: You'll be asked to authorize the app to access your Spotify account
+3. **Token Exchange**: The library exchanges the authorization code for access and refresh tokens
+4. **Token Caching**: Tokens are automatically saved to `.spotify_token_cache.json` for future use
+    * This happens is this script and tooling here is primarily for local testing.
+
+### Subsequent Runs
+
+On subsequent runs, the library will:
+
+1. **Load Cached Tokens**: Automatically load tokens from the cache file
+2. **Validate Tokens**: Test the cached tokens to ensure they're still valid
+3. **Use Cached Tokens**: If valid, use them directly without re-authentication
+4. **Auto-Refresh**: If access token expires, automatically refresh using the refresh token
+5. **Re-authenticate**: Only if tokens are completely invalid (e.g., revoked by user)
+
+### Token Cache Management
 
 ```python
 from src.spotify import SpotifyClient

--- a/README.md
+++ b/README.md
@@ -74,21 +74,9 @@ On subsequent runs, the library will:
 ```python
 from src.spotify import SpotifyClient
 
-async with SpotifyClient() as client:
-    # Get user's playlists
-    playlists = await client.get_user_playlists()
-    
-    # Create a new playlist
-    playlist = await client.create_playlist(
-        name="My Playlist",
-        description="A test playlist"
-    )
-    
-    # Add tracks
-    await client.add_tracks_to_playlist(
-        playlist_id=playlist.id,
-        track_ids=["spotify:track:4iV5W9uYEdYUVa79Axb7Rh"]
-    )
+# Clear the authentication cache (forces re-authentication)
+client = SpotifyClient()
+client.clear_auth_cache()
 ```
 
 ## 📚 Examples

--- a/README.md
+++ b/README.md
@@ -190,16 +190,14 @@ uv run ruff check . && uv run ruff format --check . && uv run pyright
 spotify-api-examples/
 ├── src/
 │   ├── __init__.py
-│   ├── cli.py              # CLI interface
 │   ├── config.py           # Configuration management
 │   ├── models.py           # Pydantic models
 │   ├── spotify.py          # Main Spotify client
-│   └── utils.py            # Utility functions
+# NOTE: tests have not been written yet! TODO
 ├── tests/
 │   ├── __init__.py
 │   ├── conftest.py         # Test configuration
-│   ├── test_playlists.py   # Playlist tests
-│   └── test_spotify.py     # Client tests
+│   ├── test_models.py      # Model tests
 ├── .env.example            # Environment template
 ├── .gitignore
 ├── pyproject.toml          # Project configuration

--- a/README.md
+++ b/README.md
@@ -136,6 +136,37 @@ async def create_playlist_example():
         await client.add_tracks_to_playlist(playlist.id, track_uris)
         print(f"Added {len(track_uris)} tracks to {playlist.name}")
 ```
+
+### Search and Discovery
+
+```python
+async def search_example():
+    async with SpotifyClient() as client:
+        # Search for tracks
+        tracks = await client.search_tracks("artist:Queen", limit=10)
+        
+        # Search for playlists
+        results = await client.search("workout", ["playlist"], limit=5)
+        playlists = results.playlists.items if results.playlists else []
+        
+        print(f"Found {len(tracks)} tracks and {len(playlists)} playlists")
+```
+
+### Error Handling
+
+```python
+from src.spotify import SpotifyClient, SpotifyAPIError
+
+async def error_handling_example():
+    async with SpotifyClient() as client:
+        try:
+            playlist = await client.get_playlist("invalid_playlist_id")
+        except SpotifyAPIError as e:
+            print(f"API Error: {e}")
+            print(f"Status Code: {e.status_code}")
+        except Exception as e:
+            print(f"Unexpected error: {e}")
+```
 ## 🔧 Development
 
 ### Code Quality

--- a/README.md
+++ b/README.md
@@ -80,6 +80,25 @@ client.clear_auth_cache()
 ```
 
 ## 📚 Examples
+## 🎯 Quick Start
+
+The easiest way to get started is with the comprehensive example script:
+
+```bash
+uv run python -m examples.basic_usage
+```
+**What it demonstrates:**
+- User authentication and profile retrieval
+- Playlist management (create, read, update)
+- Track search and discovery
+- Playlist modification (adding tracks)
+> [!TIP]
+> **Quick Start**: The `basic_usage.py` script is the best way to get started! It provides a complete demonstration of all the library's features with beautiful console output using Rich. Run it after setting up your `.env` file to see everything in action.
+> 
+> **Token Persistence**: Authentication tokens are automatically cached in `.spotify_token_cache.json` and will be reused on subsequent runs, so you won't need to re-authenticate each time!
+
+> [!IMPORTANT]
+> This will create playlists in your account!
 
 ### Basic Playlist Operations
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Secure examples and tools for working with the [Spotify Web API](https://develop
 - **Type-safe API interactions** with Pydantic models
 - **Modern Python tooling** with uv, ruff, and pyright
 - **Comprehensive examples** for all playlist endpoints
-- **CLI interface** for easy testing and exploration
+- **Token persistence** for seamless authentication
 - **Async support** for high-performance operations
 
 ## 📋 Prerequisites

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -198,3 +198,17 @@ async def main():
     except Exception as e:
         display_error("Unexpected Error", str(e))
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    # Check if .env file exists
+    env_file = Path(__file__).parent.parent / ".env"
+    if not env_file.exists():
+        console.print(Panel.fit(
+            "[bold red]❌ .env file not found![/bold red]\n\n[dim]Please copy env.example to .env and add your Spotify credentials.[/dim]",
+            border_style="red"
+        ))
+        sys.exit(1)
+
+    # Run the example
+    asyncio.run(main())

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -111,3 +111,11 @@ async def add_tracks_to_playlist(client: SpotifyClient, playlist, tracks):
     return snapshot_id
 
 
+async def display_updated_playlist(client: SpotifyClient, playlist):
+    """Display the updated playlist information."""
+    console.print("\n[bold cyan]6. Getting updated playlist...[/bold cyan]")
+    updated_playlist = await client.get_playlist(playlist.id)
+    console.print(f"   📊 Playlist now has [bold yellow]{updated_playlist.track_count}[/bold yellow] tracks")
+    console.print(f"   ⏱️  Total duration: [bold yellow]{updated_playlist.duration_formatted}[/bold yellow]")
+    return updated_playlist
+

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Basic usage example for Spotify API client.
+NOTE: This will generate playlists in your account!
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+# Import from the src package
+from src.spotify import SpotifyAPIError, SpotifyAuthError, SpotifyClient
+
+console = Console()
+
+
+async def get_user_info(client: SpotifyClient):
+    """Get and display current user information."""
+    console.print("\n[bold cyan]1. Getting current user...[/bold cyan]")
+    user = await client.get_current_user()
+    console.print(f"   👋 Welcome, [bold green]{user.display_name}[/bold green]!")
+    console.print(f"   🆔 User ID: [dim]{user.id}[/dim]")
+    return user

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -54,3 +54,30 @@ async def display_user_playlists(client: SpotifyClient):
         console.print(f"   [dim]... and {len(playlists) - 5} more playlists (showing top 5)[/dim]")
     return playlists
 
+
+async def search_and_display_tracks(client: SpotifyClient):
+    """Search for tracks and display results in a table."""
+    console.print("\n[bold cyan]3. Searching for tracks...[/bold cyan]")
+    search_query = "artist:Queen"
+    tracks = await client.search_tracks(search_query, limit=5)
+    console.print(f"   🔍 Found [bold yellow]{len(tracks)}[/bold yellow] tracks for '[italic]{search_query}[/italic]':")
+
+    # Create a table for tracks
+    track_table = Table(show_header=True, header_style="bold magenta")
+    track_table.add_column("Title", style="cyan", width=25)
+    track_table.add_column("Artist", style="blue", width=20)
+    track_table.add_column("Album", style="green", width=25)
+    track_table.add_column("Duration", style="yellow", justify="center")
+
+    for track in tracks:
+        artists = ", ".join(artist.name for artist in track.artists)
+        track_table.add_row(
+            track.name,
+            artists,
+            track.album.name,
+            track.duration_formatted
+        )
+
+    console.print(track_table)
+    return tracks
+

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
 """Basic usage example for Spotify API client.
+
+This example demonstrates:
+1. Getting current user (`get_user_info`)
+2. Listing user's playlists (`display_user_playlists`)
+3. Searching for tracks (`search_and_display_tracks`)
+4. Create a playlist (`create_test_playlist`)
+5. Add tracks to a playlist (`add_tracks_to_playlist`)
+6. Display updated playlist (`display_updated_playlist`)
+7. Track Info (`display_track_info`)
+
+Before running this script, make sure to:
+1. Set up your Spotify API credentials in a .env file
+2. Install dependencies: uv sync
+
 NOTE: This will generate playlists in your account!
 """
 

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -119,3 +119,30 @@ async def display_updated_playlist(client: SpotifyClient, playlist):
     console.print(f"   ⏱️  Total duration: [bold yellow]{updated_playlist.duration_formatted}[/bold yellow]")
     return updated_playlist
 
+
+def display_track_info(track):
+    """Display track information."""
+    console.print("\n[bold cyan]7. Getting Track Info...[/bold cyan]")
+    table = Table(show_header=True, header_style="bold green", title="Track Information")
+    table.add_column("Property", style="cyan", width=20)
+    table.add_column("Value", style="yellow", width=40)
+    
+    # Basic track information
+    table.add_row("Name", track.name)
+    table.add_row("Artists", ", ".join(artist.name for artist in track.artists))
+    table.add_row("Album", track.album.name)
+    table.add_row("Duration", f"{track.duration_ms // 1000 // 60}:{track.duration_ms // 1000 % 60:02d}")
+    table.add_row("Popularity", f"{track.popularity}/100")
+    table.add_row("Explicit", "Yes" if track.explicit else "No")
+    table.add_row("Track Number", str(track.track_number))
+    table.add_row("Disc Number", str(track.disc_number))
+    
+    console.print(table)
+    
+    console.print("\n   [dim]💡 Tip: Audio features endpoint is depricated. Track Information:[/dim]")
+    console.print("   [dim]   • Track metadata (duration, popularity, explicit content)[/dim]")
+    console.print("   [dim]   • Album information[/dim]")
+    console.print("   [dim]   • Artist details[/dim]")
+    console.print("   [dim]   • Playlist analysis[/dim]")
+
+

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -60,12 +60,14 @@ async def display_user_playlists(client: SpotifyClient):
             playlist_data.get("name", "Unknown"),
             str(tracks_count),
             is_public,
-            playlist_data.get("id", "Unknown")
+            playlist_data.get("id", "Unknown"),
         )
 
     console.print(table)
     if len(playlists) > 5:
-        console.print(f"   [dim]... and {len(playlists) - 5} more playlists (showing top 5)[/dim]")
+        console.print(
+            f"   [dim]... and {len(playlists) - 5} more playlists (showing top 5)[/dim]"
+        )
     return playlists
 
 
@@ -74,7 +76,9 @@ async def search_and_display_tracks(client: SpotifyClient):
     console.print("\n[bold cyan]3. Searching for tracks...[/bold cyan]")
     search_query = "artist:Queen"
     tracks = await client.search_tracks(search_query, limit=5)
-    console.print(f"   🔍 Found [bold yellow]{len(tracks)}[/bold yellow] tracks for '[italic]{search_query}[/italic]':")
+    console.print(
+        f"   🔍 Found [bold yellow]{len(tracks)}[/bold yellow] tracks for '[italic]{search_query}[/italic]':"
+    )
 
     # Create a table for tracks
     track_table = Table(show_header=True, header_style="bold magenta")
@@ -86,10 +90,7 @@ async def search_and_display_tracks(client: SpotifyClient):
     for track in tracks:
         artists = ", ".join(artist.name for artist in track.artists)
         track_table.add_row(
-            track.name,
-            artists,
-            track.album.name,
-            track.duration_formatted
+            track.name, artists, track.album.name, track.duration_formatted
         )
 
     console.print(track_table)
@@ -107,7 +108,9 @@ async def create_test_playlist(client: SpotifyClient):
     )
     console.print(f"   ✅ Created playlist: [bold green]{playlist.name}[/bold green]")
     console.print(f"   🆔 Playlist ID: [dim]{playlist.id}[/dim]")
-    console.print(f"   🔗 URL: [link={playlist.external_urls.spotify}]{playlist.external_urls.spotify}[/link]")
+    console.print(
+        f"   🔗 URL: [link={playlist.external_urls.spotify}]{playlist.external_urls.spotify}[/link]"
+    )
     return playlist
 
 
@@ -120,7 +123,9 @@ async def add_tracks_to_playlist(client: SpotifyClient, playlist, tracks):
     console.print("\n[bold cyan]5. Adding tracks to the playlist...[/bold cyan]")
     track_uris = [track.uri for track in tracks[:3]]  # Add first 3 tracks
     snapshot_id = await client.add_tracks_to_playlist(playlist.id, track_uris)
-    console.print(f"   ➕ Added [bold yellow]{len(track_uris)}[/bold yellow] tracks to playlist")
+    console.print(
+        f"   ➕ Added [bold yellow]{len(track_uris)}[/bold yellow] tracks to playlist"
+    )
     console.print(f"   📸 Snapshot ID: [dim]{snapshot_id}[/dim]")
     return snapshot_id
 
@@ -129,32 +134,45 @@ async def display_updated_playlist(client: SpotifyClient, playlist):
     """Display the updated playlist information."""
     console.print("\n[bold cyan]6. Getting updated playlist...[/bold cyan]")
     updated_playlist = await client.get_playlist(playlist.id)
-    console.print(f"   📊 Playlist now has [bold yellow]{updated_playlist.track_count}[/bold yellow] tracks")
-    console.print(f"   ⏱️  Total duration: [bold yellow]{updated_playlist.duration_formatted}[/bold yellow]")
+    console.print(
+        f"   📊 Playlist now has [bold yellow]{updated_playlist.track_count}[/bold yellow] tracks"
+    )
+    console.print(
+        f"   ⏱️  Total duration: [bold yellow]{updated_playlist.duration_formatted}[/bold yellow]"
+    )
     return updated_playlist
 
 
 def display_track_info(track):
     """Display track information."""
     console.print("\n[bold cyan]7. Getting Track Info...[/bold cyan]")
-    table = Table(show_header=True, header_style="bold green", title="Track Information")
+    table = Table(
+        show_header=True, header_style="bold green", title="Track Information"
+    )
     table.add_column("Property", style="cyan", width=20)
     table.add_column("Value", style="yellow", width=40)
-    
+
     # Basic track information
     table.add_row("Name", track.name)
     table.add_row("Artists", ", ".join(artist.name for artist in track.artists))
     table.add_row("Album", track.album.name)
-    table.add_row("Duration", f"{track.duration_ms // 1000 // 60}:{track.duration_ms // 1000 % 60:02d}")
+    table.add_row(
+        "Duration",
+        f"{track.duration_ms // 1000 // 60}:{track.duration_ms // 1000 % 60:02d}",
+    )
     table.add_row("Popularity", f"{track.popularity}/100")
     table.add_row("Explicit", "Yes" if track.explicit else "No")
     table.add_row("Track Number", str(track.track_number))
     table.add_row("Disc Number", str(track.disc_number))
-    
+
     console.print(table)
-    
-    console.print("\n   [dim]💡 Tip: Audio features endpoint is depricated. Track Information:[/dim]")
-    console.print("   [dim]   • Track metadata (duration, popularity, explicit content)[/dim]")
+
+    console.print(
+        "\n   [dim]💡 Tip: Audio features endpoint is depricated. Track Information:[/dim]"
+    )
+    console.print(
+        "   [dim]   • Track metadata (duration, popularity, explicit content)[/dim]"
+    )
     console.print("   [dim]   • Album information[/dim]")
     console.print("   [dim]   • Artist details[/dim]")
     console.print("   [dim]   • Playlist analysis[/dim]")
@@ -162,27 +180,33 @@ def display_track_info(track):
 
 def display_success():
     """Display success message."""
-    console.print(Panel.fit(
-        "[bold green]✅ Example completed successfully![/bold green]\n[dim]All operations completed without errors.[/dim]",
-        border_style="green"
-    ))
+    console.print(
+        Panel.fit(
+            "[bold green]✅ Example completed successfully![/bold green]\n[dim]All operations completed without errors.[/dim]",
+            border_style="green",
+        )
+    )
 
 
 def display_error(error_type: str, error_message: str, additional_info: str = ""):
     """Display formatted error message."""
-    console.print(Panel.fit(
-        f"[bold red]❌ {error_type}[/bold red]\n[red]{error_message}[/red]\n\n[dim]{additional_info}[/dim]",
-        border_style="red"
-    ))
+    console.print(
+        Panel.fit(
+            f"[bold red]❌ {error_type}[/bold red]\n[red]{error_message}[/red]\n\n[dim]{additional_info}[/dim]",
+            border_style="red",
+        )
+    )
 
 
 async def main():
     """Main example function."""
     # Header
-    console.print(Panel.fit(
-        "[bold blue]🎵 Spotify API Examples[/bold blue]\n[dim]Basic Usage Demo[/dim]",
-        border_style="blue"
-    ))
+    console.print(
+        Panel.fit(
+            "[bold blue]🎵 Spotify API Examples[/bold blue]\n[dim]Basic Usage Demo[/dim]",
+            border_style="blue",
+        )
+    )
 
     try:
         async with SpotifyClient() as client:
@@ -203,7 +227,7 @@ async def main():
         display_error(
             "Authentication Error",
             str(e),
-            "Make sure your .env file contains valid Spotify credentials."
+            "Make sure your .env file contains valid Spotify credentials.",
         )
         sys.exit(1)
     except SpotifyAPIError as e:
@@ -218,10 +242,12 @@ if __name__ == "__main__":
     # Check if .env file exists
     env_file = Path(__file__).parent.parent / ".env"
     if not env_file.exists():
-        console.print(Panel.fit(
-            "[bold red]❌ .env file not found![/bold red]\n\n[dim]Please copy env.example to .env and add your Spotify credentials.[/dim]",
-            border_style="red"
-        ))
+        console.print(
+            Panel.fit(
+                "[bold red]❌ .env file not found![/bold red]\n\n[dim]Please copy env.example to .env and add your Spotify credentials.[/dim]",
+                border_style="red",
+            )
+        )
         sys.exit(1)
 
     # Run the example

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -153,3 +153,11 @@ def display_success():
         border_style="green"
     ))
 
+
+def display_error(error_type: str, error_message: str, additional_info: str = ""):
+    """Display formatted error message."""
+    console.print(Panel.fit(
+        f"[bold red]❌ {error_type}[/bold red]\n[red]{error_message}[/red]\n\n[dim]{additional_info}[/dim]",
+        border_style="red"
+    ))
+

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -146,3 +146,10 @@ def display_track_info(track):
     console.print("   [dim]   • Playlist analysis[/dim]")
 
 
+def display_success():
+    """Display success message."""
+    console.print(Panel.fit(
+        "[bold green]✅ Example completed successfully![/bold green]\n[dim]All operations completed without errors.[/dim]",
+        border_style="green"
+    ))
+

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -24,3 +24,33 @@ async def get_user_info(client: SpotifyClient):
     console.print(f"   👋 Welcome, [bold green]{user.display_name}[/bold green]!")
     console.print(f"   🆔 User ID: [dim]{user.id}[/dim]")
     return user
+
+
+async def display_user_playlists(client: SpotifyClient):
+    """Display user's playlists in a formatted table."""
+    console.print("\n[bold cyan]2. Fetching your playlists...[/bold cyan]")
+    playlists = await client.get_user_playlists(limit=10)
+    console.print(f"   📚 Found [bold yellow]{len(playlists)}[/bold yellow] playlists:")
+
+    # Create a table for playlists
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Name", style="cyan", width=30)
+    table.add_column("Tracks", style="yellow", justify="center")
+    table.add_column("Public", style="green", justify="center")
+    table.add_column("ID", style="dim", width=22)
+
+    for playlist_data in playlists[:5]:  # Show first 5
+        tracks_count = playlist_data.get("tracks", {}).get("total", 0)
+        is_public = "✓" if playlist_data.get("public", False) else "✗"
+        table.add_row(
+            playlist_data.get("name", "Unknown"),
+            str(tracks_count),
+            is_public,
+            playlist_data.get("id", "Unknown")
+        )
+
+    console.print(table)
+    if len(playlists) > 5:
+        console.print(f"   [dim]... and {len(playlists) - 5} more playlists (showing top 5)[/dim]")
+    return playlists
+

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -96,3 +96,18 @@ async def create_test_playlist(client: SpotifyClient):
     console.print(f"   🔗 URL: [link={playlist.external_urls.spotify}]{playlist.external_urls.spotify}[/link]")
     return playlist
 
+
+async def add_tracks_to_playlist(client: SpotifyClient, playlist, tracks):
+    """Add tracks to the specified playlist."""
+    if not tracks:
+        console.print("\n[bold yellow]⚠️  No tracks to add to playlist[/bold yellow]")
+        return None
+
+    console.print("\n[bold cyan]5. Adding tracks to the playlist...[/bold cyan]")
+    track_uris = [track.uri for track in tracks[:3]]  # Add first 3 tracks
+    snapshot_id = await client.add_tracks_to_playlist(playlist.id, track_uris)
+    console.print(f"   ➕ Added [bold yellow]{len(track_uris)}[/bold yellow] tracks to playlist")
+    console.print(f"   📸 Snapshot ID: [dim]{snapshot_id}[/dim]")
+    return snapshot_id
+
+

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -161,3 +161,40 @@ def display_error(error_type: str, error_message: str, additional_info: str = ""
         border_style="red"
     ))
 
+
+async def main():
+    """Main example function."""
+    # Header
+    console.print(Panel.fit(
+        "[bold blue]🎵 Spotify API Examples[/bold blue]\n[dim]Basic Usage Demo[/dim]",
+        border_style="blue"
+    ))
+
+    try:
+        async with SpotifyClient() as client:
+            # Execute all operations
+            await get_user_info(client)
+            await display_user_playlists(client)
+            tracks = await search_and_display_tracks(client)
+            playlist = await create_test_playlist(client)
+            await add_tracks_to_playlist(client, playlist, tracks)
+            await display_updated_playlist(client, playlist)
+            # NOTE: for now just display the first track's info
+            display_track_info(tracks[0])
+
+            # Success message
+            display_success()
+
+    except SpotifyAuthError as e:
+        display_error(
+            "Authentication Error",
+            str(e),
+            "Make sure your .env file contains valid Spotify credentials."
+        )
+        sys.exit(1)
+    except SpotifyAPIError as e:
+        display_error("API Error", str(e))
+        sys.exit(1)
+    except Exception as e:
+        display_error("Unexpected Error", str(e))
+        sys.exit(1)

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -81,3 +81,18 @@ async def search_and_display_tracks(client: SpotifyClient):
     console.print(track_table)
     return tracks
 
+
+async def create_test_playlist(client: SpotifyClient):
+    """Create a new test playlist."""
+    console.print("\n[bold cyan]4. Creating a new playlist...[/bold cyan]")
+    playlist_name = "API Test Playlist"
+    playlist = await client.create_playlist(
+        name=playlist_name,
+        description="Created with Spotify API examples",
+        public=False,
+    )
+    console.print(f"   ✅ Created playlist: [bold green]{playlist.name}[/bold green]")
+    console.print(f"   🆔 Playlist ID: [dim]{playlist.id}[/dim]")
+    console.print(f"   🔗 URL: [link={playlist.external_urls.spotify}]{playlist.external_urls.spotify}[/link]")
+    return playlist
+

--- a/src/models.py
+++ b/src/models.py
@@ -234,26 +234,3 @@ class SearchResult(BaseModel):
     artists: dict[str, Any] | None = None
     albums: dict[str, Any] | None = None
     playlists: dict[str, Any] | None = None
-
-
-class AudioFeatures(BaseModel):
-    """Audio features for a track."""
-
-    id: str
-    acousticness: float = Field(ge=0.0, le=1.0)
-    analysis_url: HttpUrl
-    danceability: float = Field(ge=0.0, le=1.0)
-    duration_ms: int
-    energy: float = Field(ge=0.0, le=1.0)
-    instrumentalness: float = Field(ge=0.0, le=1.0)
-    key: int = Field(ge=-1, le=11)
-    liveness: float = Field(ge=0.0, le=1.0)
-    loudness: float
-    mode: int = Field(ge=0, le=1)
-    speechiness: float = Field(ge=0.0, le=1.0)
-    tempo: float
-    time_signature: int
-    track_href: HttpUrl
-    type: str = "audio_features"
-    uri: str
-    valence: float = Field(ge=0.0, le=1.0)

--- a/src/models.py
+++ b/src/models.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, HttpUrl, field_validator
+from pydantic import BaseModel, HttpUrl, field_validator
 
 
 class ExternalUrls(BaseModel):

--- a/src/spotify.py
+++ b/src/spotify.py
@@ -13,7 +13,6 @@ from pydantic import ValidationError
 from .auth_server import AuthServer
 from .config import SpotifyConfig
 from .models import (
-    AudioFeatures,
     Playlist,
     SearchResult,
     Track,
@@ -387,15 +386,11 @@ class SpotifyClient:
             return [Track.model_validate(item) for item in result.tracks["items"]]
         return []
 
-    async def get_track_audio_features(self, track_id: str) -> AudioFeatures:
-        """Get audio features for a track."""
-        data = await self._make_request("GET", f"/audio-features/{track_id}")
-        return AudioFeatures.model_validate(data)
-
-    async def get_tracks_audio_features(
-        self, track_ids: list[str]
-    ) -> list[AudioFeatures]:
-        """Get audio features for multiple tracks."""
-        params = {"ids": ",".join(track_ids)}
-        data = await self._make_request("GET", "/audio-features", params=params)
-        return [AudioFeatures.model_validate(item) for item in data["audio_features"]]
+    async def get_track(self, track_id: str, market: str | None = None) -> Track:
+        """Get track details."""
+        params = {}
+        if market:
+            params["market"] = market
+        
+        data = await self._make_request("GET", f"/tracks/{track_id}", params=params)
+        return Track.model_validate(data)

--- a/src/spotify.py
+++ b/src/spotify.py
@@ -29,6 +29,7 @@ TOKEN_CACHE_FILE = Path(".spotify_token_cache.json")
 
 class SpotifyAuthError(Exception):
     """Raised when authentication fails."""
+
     pass
 
 
@@ -104,10 +105,10 @@ class SpotifyClient:
         """Load tokens from cache file if available."""
         try:
             if TOKEN_CACHE_FILE.exists():
-                with open(TOKEN_CACHE_FILE, 'r') as f:
+                with open(TOKEN_CACHE_FILE) as f:
                     token_data = json.load(f)
-                    self._access_token = token_data.get('access_token')
-                    self._refresh_token = token_data.get('refresh_token')
+                    self._access_token = token_data.get("access_token")
+                    self._refresh_token = token_data.get("refresh_token")
                     logger.info("Loaded tokens from cache")
                     return True
         except Exception as e:
@@ -119,10 +120,10 @@ class SpotifyClient:
         try:
             if self._access_token and self._refresh_token:
                 token_data = {
-                    'access_token': self._access_token,
-                    'refresh_token': self._refresh_token,
+                    "access_token": self._access_token,
+                    "refresh_token": self._refresh_token,
                 }
-                with open(TOKEN_CACHE_FILE, 'w') as f:
+                with open(TOKEN_CACHE_FILE, "w") as f:
                     json.dump(token_data, f)
                 logger.info("Saved tokens to cache")
         except Exception as e:
@@ -456,6 +457,6 @@ class SpotifyClient:
         params = {}
         if market:
             params["market"] = market
-        
+
         data = await self._make_request("GET", f"/tracks/{track_id}", params=params)
         return Track.model_validate(data)

--- a/src/spotify.py
+++ b/src/spotify.py
@@ -451,12 +451,3 @@ class SpotifyClient:
         if result.tracks and "items" in result.tracks:
             return [Track.model_validate(item) for item in result.tracks["items"]]
         return []
-
-    async def get_track(self, track_id: str, market: str | None = None) -> Track:
-        """Get track details."""
-        params = {}
-        if market:
-            params["market"] = market
-
-        data = await self._make_request("GET", f"/tracks/{track_id}", params=params)
-        return Track.model_validate(data)


### PR DESCRIPTION
* Adds a `.spotify_token_cache.json` for local testing and re-running. Don't re-auth each time.
    * IF token is valid use it. Else refresh it.
* Removes all `audio features` logic: as I thought it was a cool idea but endpoints [deprecated by spotify](https://developer.spotify.com/documentation/web-api/reference/get-audio-features).
* Adds method to `get_track_info` instead.
* Adds a `basic_usage.py` script to validate all functionality.
* This was added for the time being instead of a `cli` and/or unit tests.
* This repo is currently WIP/Demo state. 